### PR TITLE
Revert "Update golang version to 1.22"

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.0
+golang 1.21.8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.21 as builder
 
 ENV CGO_ENABLED="0" \
     GOOS="linux" \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/h3poteto/aws-global-accelerator-controller
 
-go 1.22
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go v1.51.11


### PR DESCRIPTION
Reverts h3poteto/aws-global-accelerator-controller#148

Refs: https://github.com/kubernetes-sigs/kubebuilder/issues/3792
controller-gen does not support 1.22 yet.