### PR TITLE
feat(route53): add support for zone filtering

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -17,8 +17,9 @@ import (
 )
 
 type options struct {
-	workers     int
-	clusterName string
+	workers       int
+	clusterName   string
+	route53ZoneID string
 }
 
 func ControllerCmd() *cobra.Command {
@@ -31,6 +32,7 @@ func ControllerCmd() *cobra.Command {
 	flags := cmd.Flags()
 	flags.IntVarP(&o.workers, "workers", "w", 1, "Concurrent workers number for controller.")
 	flags.StringVarP(&o.clusterName, "cluster-name", "c", "default", "Owner cluster name which is used in resource tags.")
+	flags.StringVar(&o.route53ZoneID, "route53-zone-id", "", "ID of the Route53 zone. Only relevant in case multiple zones share the same DNS name and you want to target a single one of them.")
 
 	cmd.PersistentFlags().String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	cmd.PersistentFlags().String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
@@ -62,8 +64,9 @@ func (o *options) run(cmd *cobra.Command, args []string) {
 			ClusterName: o.clusterName,
 		},
 		Route53: &route53.Route53Config{
-			Workers:     o.workers,
-			ClusterName: o.clusterName,
+			Workers:       o.workers,
+			ClusterName:   o.clusterName,
+			Route53ZoneID: o.route53ZoneID,
 		},
 		EndpointGroupBinding: &endpointgroupbinding.EndpointGroupBindingConfig{
 			Workers: o.workers,

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -10,12 +10,17 @@ import (
 )
 
 type AWS struct {
-	lb      *elbv2.Client
-	ga      *globalaccelerator.Client
-	route53 *route53.Client
+	lb            *elbv2.Client
+	ga            *globalaccelerator.Client
+	route53       *route53.Client
+	route53ZoneID string
 }
 
 func NewAWS(region string) (*AWS, error) {
+	return NewAWSWithRoute53ZoneID(region, "")
+}
+
+func NewAWSWithRoute53ZoneID(region string, route53ZoneID string) (*AWS, error) {
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return nil, err
@@ -31,8 +36,9 @@ func NewAWS(region string) (*AWS, error) {
 		o.Region = "us-west-2"
 	})
 	return &AWS{
-		lb:      lb,
-		ga:      ga,
-		route53: route53,
+		lb:            lb,
+		ga:            ga,
+		route53:       route53,
+		route53ZoneID: route53ZoneID,
 	}, nil
 }

--- a/pkg/controller/route53/controller.go
+++ b/pkg/controller/route53/controller.go
@@ -29,12 +29,14 @@ import (
 const controllerAgentName = "route53-controller"
 
 type Route53Config struct {
-	Workers     int
-	ClusterName string
+	Workers       int
+	ClusterName   string
+	Route53ZoneID string
 }
 
 type Route53Controller struct {
 	clusterName   string
+	route53ZoneID string
 	kubeclint     kubernetes.Interface
 	serviceLister corelisters.ServiceLister
 	serviceSynced cache.InformerSynced
@@ -54,11 +56,12 @@ func NewRoute53Controller(kubeclient kubernetes.Interface, informerFactory infor
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
 	controller := &Route53Controller{
-		clusterName:  config.ClusterName,
-		kubeclint:    kubeclient,
-		recorder:     recorder,
-		serviceQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerAgentName+"-service"),
-		ingressQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerAgentName+"-ingress"),
+		clusterName:   config.ClusterName,
+		route53ZoneID: config.Route53ZoneID,
+		kubeclint:     kubeclient,
+		recorder:      recorder,
+		serviceQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerAgentName+"-service"),
+		ingressQueue:  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerAgentName+"-ingress"),
 	}
 	{
 		f := informerFactory.Core().V1().Services()

--- a/pkg/controller/route53/ingress.go
+++ b/pkg/controller/route53/ingress.go
@@ -23,7 +23,7 @@ func (c *Route53Controller) processIngressDelete(ctx context.Context, key string
 	if err != nil {
 		return reconcile.Result{}, pkgerrors.NewNoRetryErrorf("invalid resource key: %s", key)
 	}
-	cloud, err := cloudaws.NewAWS("us-west-2")
+	cloud, err := cloudaws.NewAWSWithRoute53ZoneID("us-west-2", c.route53ZoneID)
 	if err != nil {
 		klog.Error(err)
 		return reconcile.Result{}, err
@@ -45,7 +45,7 @@ func (c *Route53Controller) processIngressCreateOrUpdate(ctx context.Context, ob
 
 	hostname, ok := ingress.Annotations[apis.Route53HostnameAnnotation]
 	if !ok {
-		cloud, err := cloudaws.NewAWS("us-west-2")
+		cloud, err := cloudaws.NewAWSWithRoute53ZoneID("us-west-2", c.route53ZoneID)
 		if err != nil {
 			klog.Error(err)
 			return reconcile.Result{}, err
@@ -76,7 +76,7 @@ func (c *Route53Controller) processIngressCreateOrUpdate(ctx context.Context, ob
 				klog.Error(err)
 				return reconcile.Result{}, err
 			}
-			cloud, err := cloudaws.NewAWS(region)
+			cloud, err := cloudaws.NewAWSWithRoute53ZoneID(region, c.route53ZoneID)
 			if err != nil {
 				klog.Error(err)
 				return reconcile.Result{}, err

--- a/pkg/controller/route53/service.go
+++ b/pkg/controller/route53/service.go
@@ -32,7 +32,7 @@ func (c *Route53Controller) processServiceDelete(ctx context.Context, key string
 	if err != nil {
 		return reconcile.Result{}, pkgerrors.NewNoRetryErrorf("invalid resource key: %s", key)
 	}
-	cloud, err := cloudaws.NewAWS("us-west-2")
+	cloud, err := cloudaws.NewAWSWithRoute53ZoneID("us-west-2", c.route53ZoneID)
 	if err != nil {
 		klog.Error(err)
 		return reconcile.Result{}, err
@@ -53,7 +53,7 @@ func (c *Route53Controller) processServiceCreateOrUpdate(ctx context.Context, ob
 
 	hostname, ok := svc.Annotations[apis.Route53HostnameAnnotation]
 	if !ok {
-		cloud, err := cloudaws.NewAWS("us-west-2")
+		cloud, err := cloudaws.NewAWSWithRoute53ZoneID("us-west-2", c.route53ZoneID)
 		if err != nil {
 			klog.Error(err)
 			return reconcile.Result{}, err
@@ -84,7 +84,7 @@ func (c *Route53Controller) processServiceCreateOrUpdate(ctx context.Context, ob
 				klog.Error(err)
 				return reconcile.Result{}, err
 			}
-			cloud, err := cloudaws.NewAWS(region)
+			cloud, err := cloudaws.NewAWSWithRoute53ZoneID(region, c.route53ZoneID)
 			if err != nil {
 				klog.Error(err)
 				return reconcile.Result{}, err


### PR DESCRIPTION
Hi,

Currently, the controller identifies the Route53 zone it needs to handle by selecting the first one that matches the hostnames. Since we have both a private and a public zone for each DNS name, this approach leads to random and unpredictable behavior.

This pull request introduces a `route53-zone-id` flag, allowing users to specify the exact zone they want to target. This enhancement is essential for us to reliably use the controller in our production environments and also helps to reduce the required IAM permissions.

This change does not address any existing PR. If the implementation does not meet your requirements or if you believe this use case is not relevant, please let me know.

Thank you for developing this controller—it has been invaluable in managing GA across our multi-region deployments.