### PR TITLE
Revert golang version to 1.22

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.23.6
+golang 1.22.5

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/h3poteto/aws-global-accelerator-controller
 
-go 1.23
+go 1.22.0
 
-toolchain go1.23.6
+toolchain go1.22.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.4


### PR DESCRIPTION
kube_codegen.sh removes generated code in golang 1.23.